### PR TITLE
Resolved bento warnings

### DIFF
--- a/adjust
+++ b/adjust
@@ -134,7 +134,7 @@ def read_desc():
     """load the user-defined descriptor, returning a dictionary of the contents under the k8s top-level key, if any"""
     try:
         f = open(DESC_FILE)
-        desc = yaml.load(f)
+        desc = yaml.safe_load(f)
     except IOError as e:
         if e.errno == errno.ENOENT:
             raise ConfigError('configuration file {} does not exist'.format(DESC_FILE))

--- a/tst/helpers.py
+++ b/tst/helpers.py
@@ -48,11 +48,13 @@ def setcfg(fname):
 
 def run(cmd):
     """basic execution of a command, stdout and stderr are not redirected (end up in py.test logs), raise exception on errors"""
-    subprocess.run(cmd, shell=True, check=True)
+    # nosec below as test suite is not intended to run in production environment, invocations all use static input
+    subprocess.run(cmd, shell=True, check=True) # nosec
 
 def silent(cmd):
     """run a command and ignore stdout/stderr and non-zero exit status"""
-    subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+    # nosec below as test suite is not intended to run in production environment, invocations all use static input
+    subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False) # nosec
 
 # === 
 import shutil
@@ -63,14 +65,16 @@ import yaml
 def setup_deployment(dep):
     cleanup_deployment(dep)
     cmd = 'kubectl create -f -'
-    subprocess.run(cmd, input=bytearray(dep.encode('utf-8')), shell=True, check=True,
+    # nosec below as test suite is not intended to run in production environment, invocations all use static input
+    subprocess.run(cmd, input=bytearray(dep.encode('utf-8')), shell=True, check=True, # nosec
                    stdout=subprocess.DEVNULL)
 
 
 def cleanup_deployment(dep):
-    dep = yaml.load(dep)
+    dep = yaml.safe_load(dep)
     cmd = 'kubectl delete deployment {dep}'.format(dep=dep['metadata']['name'])
-    proc = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
+    # nosec below as test suite is not intended to run in production environment, invocations all use static input
+    proc = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE) # nosec
     if proc.stderr and 'not found' in str(proc.stderr, encoding='utf-8'):
         return
     proc.check_returncode()
@@ -105,7 +109,8 @@ def copy_driver_files(tmpdirname, cfg):
 
 def run_driver(params, input=None):
     cmd = './adjust {}'.format(params)
-    proc = subprocess.run(cmd, input=input, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, check=True)
+    # nosec below as test suite is not intended to run in production environment, invocations all use static input
+    proc = subprocess.run(cmd, input=input, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, check=True) # nosec
     assert proc.stdout
     stdout = json.loads(str(proc.stdout.strip(), encoding='utf-8').split('\n')[-1])
     return stdout, str(proc.stderr, encoding='utf-8'), proc.returncode


### PR DESCRIPTION
Bento Output:

```
bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html  
     > adjust_driver.py:137                                                           
     ╷                                                                                
  137│   desc = yaml.load(f)                                                          
     ╵
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > tst/helpers.py:51
     ╷
   51│   subprocess.run(cmd, shell=True, check=True)
     ╵
     = subprocess call with shell=True identified, security issue.

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > tst/helpers.py:55
     ╷
   55│   subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
     ╵
     = subprocess call with shell=True identified, security issue.

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > tst/helpers.py:66
     ╷
   66│   subprocess.run(cmd, input=bytearray(dep.encode('utf-8')), shell=True, check=True,
   67│                  stdout=subprocess.DEVNULL)
     ╵
     = subprocess call with shell=True identified, security issue.

bandit yaml-load https://bandit.readthedocs.io/en/latest/plugins/b506_yaml_load.html
     > tst/helpers.py:71
     ╷
   71│   dep = yaml.load(dep)
     ╵
     = Use of unsafe yaml load. Allows instantiation of arbitrary objects.
       Consider yaml.safe_load().

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > tst/helpers.py:73
     ╷
   73│   proc = subprocess.run(cmd, shell=True, stdout=subprocess.DEVNULL, stderr=subprocess.PIPE)
     ╵
     = subprocess call with shell=True identified, security issue.

bandit subprocess-popen-with-shell-equals-true https://bandit.readthedocs.io/en/latest/plugins/b602_subprocess_popen_with_shell_equals_true.html
     > tst/helpers.py:108
     ╷
  108│   proc = subprocess.run(cmd, input=input, stdout=subprocess.PIPE, stderr=subprocess.PIPE, shell=True, check=True)
     ╵
     = subprocess call with shell=True identified, security issue.
```