### PR TITLE
new option: 'force_restart' (restart pods even if adjust made no change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ afterward.
    `{"settings":{"cpu":0.125,"mem":0.25,"replicas":2},"time":"2020-12-30T21:24:50Z"}`. The option works only if the application
    consists of a single component. If there are multiple components defined, a warning will be printed (and no annotation will be written).
 
+- `force_restart` (boolean, default=false) if set to true, all deployments controlled by the driver are forced to
+   re-start their pods, even if the adjustment made no changes to the settings.
+
 Example `config.yaml` configuration file:
 
 ```yaml

--- a/adjust
+++ b/adjust
@@ -29,7 +29,7 @@ CPU_STEP = 0.0125  # 1.25% of a core (even though 1 millicore is the highest res
 MAX_MEM = 4 * Gi  # bytes, may be overridden to higher limit
 MAX_CPU = 4.0  # cores
 # MAX_REPLICAS = 1000 # arbitrary, TBD
-FORCED_RESTART_ANN = "optune.ai/forceRestartAt" # pod annotation to set for forced restart
+FORCED_RESTART_ANN = "servo.opsani.com/forceRestartAt" # pod annotation to set for forced restart
 
 # the k8s obj to which we make queries/updates:
 DEPLOYMENT = "deployment"

--- a/adjust
+++ b/adjust
@@ -29,13 +29,15 @@ CPU_STEP = 0.0125  # 1.25% of a core (even though 1 millicore is the highest res
 MAX_MEM = 4 * Gi  # bytes, may be overridden to higher limit
 MAX_CPU = 4.0  # cores
 # MAX_REPLICAS = 1000 # arbitrary, TBD
+FORCED_RESTART_ANN = "optune.ai/forceRestartAt" # pod annotation to set for forced restart
 
 # the k8s obj to which we make queries/updates:
 DEPLOYMENT = "deployment"
 # DEPLOYMENT = "deployment.v1.apps"  # new, not supported in 1.8 (it has v1beta1)
 RESOURCE_MAP = {"mem": "memory", "cpu": "cpu"}
 
-EXCLUDE_FROM_QUERY = ["driver", "update_annotation"]
+# top-level keys in config data that are not printed on --query
+EXCLUDE_FROM_QUERY = ["driver", "update_annotation", "force_restart"]
 
 class ConfigError(Exception): # user-provided descriptor not readable
     pass
@@ -153,7 +155,7 @@ def read_desc():
     driver_key = 'k8s'
     if os.environ.get('OPTUNE_USE_DRIVER_NAME', False):
         driver_key = os.path.basename(__file__)
-    assert driver_key in desc and desc[driver_key], 'No configuration were defined for K8s driver in config file {}. ' \
+    assert driver_key in desc and desc[driver_key], 'No configuration is defined for K8s driver in config file {}. ' \
                                           'Please set up configuration for deployments under key "{}". ' \
                                           '{}'.format(
                                               DESC_FILE, refer_tip, driver_key)
@@ -182,12 +184,20 @@ def read_desc():
 
     if len(replicas_tracker) < sum(replicas_tracker.values()):
         rotten_deps = map(lambda d: d[0], filter(lambda c: c[1] > 1, replicas_tracker.items()))
-        raise Exception('Some components have more than one setting "replicas" defined. Specifically: {}. '
+        raise Exception('Several components in the same deployment have "replicas" defined. Affected deployments: {}. '
                         'Please, keep only one "replicas" per deployment.'.format(', '.join(rotten_deps)))
 
     ann_key = desc.get("update_annotation", None)
     if ann_key is not None:
         assert isinstance(ann_key, str), "'update_annotation' must have a string value"
+    if "force_restart" in desc:
+        v = desc["force_restart"]
+        if isinstance(v, str):
+            try:
+                v = bool(int(v))
+            except Exception:
+                raise ConfigError("'force_restart' must be boolean or convertible to integer/boolean")
+        desc["force_restart"] = v
 
     return desc
 
@@ -872,6 +882,12 @@ def update(appname, desc, data, print_progress):
                 cp.append(v)
         if replicas is not None:
             patch.setdefault("spec", {})["replicas"] = replicas
+        if desc.get("force_restart", False):
+            # restart is forced simply by adding an annotation with a value that doesn't repeat - it causes
+            # the pod spec to be 'different', so the deployment will re-create the pod.
+            # (this is the same method as used by 'kubectl rollout restart')
+            ann =  patch.setdefault('spec', {}).setdefault('template', {}).setdefault('metadata', {}).setdefault('annotations', {})
+            ann[FORCED_RESTART_ANN] = datetime.datetime.utcnow().isoformat(timespec="seconds")+"Z"
 
     if not patchlst:
         raise Exception('No components were defiend in a configuration file. Cannot proceed with an adjustment.')


### PR DESCRIPTION
Implemented using the same method as 'kubectl rollout restart': modify an annotation on the pod ('optune.ai/forceRestartAt: ).